### PR TITLE
Backport --sector-size support

### DIFF
--- a/SOURCES/0001-losetup-Add-support-for-logical-block-size.patch
+++ b/SOURCES/0001-losetup-Add-support-for-logical-block-size.patch
@@ -1,0 +1,279 @@
+From 86d9c1267bbaaf1d7c9728f7a28f413fdbf9cb4f Mon Sep 17 00:00:00 2001
+From: Stanislav Brabec <sbrabec@suse.cz>
+Date: Tue, 26 Sep 2017 16:14:51 +0200
+Subject: [PATCH 1/4] losetup: Add support for logical block size
+
+Kernel since 4.14 supports setting of logical block size[1]. It allows to
+create loop devices that report logical block size different from 512.
+
+Add support for this feature to losetup.
+
+References:
+[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/drivers/block/loop.c?id=89e4fdecb51cf5535867026274bc97de9480ade5
+
+[kzak@redhat.com: - fix loopcxt_get_blocksize()
+                  - remove lo_blocksize from loop_info64]
+
+Signed-off-by: Stanislav Brabec <sbrabec@suse.cz>
+Cc: Ming Lei <ming.lei@redhat.com>
+Cc: Hannes Reinecke <hare@suse.com>
+Cc: Omar Sandoval <osandov@fb.com>
+Cc: Jens Axboe <axboe@kernel.dk>
+Signed-off-by: Karel Zak <kzak@redhat.com>
+
+(cherry picked from commit a1a41597bfd55e709024bd91aaf024159362679c)
+---
+ include/loopdev.h   |  3 +++
+ lib/loopdev.c       | 50 +++++++++++++++++++++++++++++++++++++++++++++
+ sys-utils/losetup.8 |  2 ++
+ sys-utils/losetup.c | 39 +++++++++++++++++++++++++++++++----
+ 4 files changed, 90 insertions(+), 4 deletions(-)
+
+diff --git a/include/loopdev.h b/include/loopdev.h
+index eb328a080..66ff583f9 100644
+--- a/include/loopdev.h
++++ b/include/loopdev.h
+@@ -23,6 +23,7 @@
+ #define LOOP_GET_STATUS64	0x4C05
+ /* #define LOOP_CHANGE_FD	0x4C06 */
+ #define LOOP_SET_CAPACITY	0x4C07
++#define LOOP_SET_BLOCK_SIZE	0x4C09
+ 
+ /* /dev/loop-control interface */
+ #ifndef LOOP_CTL_ADD
+@@ -170,11 +171,13 @@ int loopcxt_set_offset(struct loopdev_cxt *lc, uint64_t offset);
+ int loopcxt_set_sizelimit(struct loopdev_cxt *lc, uint64_t sizelimit);
+ int loopcxt_set_flags(struct loopdev_cxt *lc, uint32_t flags);
+ int loopcxt_set_backing_file(struct loopdev_cxt *lc, const char *filename);
++int loopcxt_set_blocksize(struct loopdev_cxt *lc, uint64_t blocksize);
+ 
+ extern char *loopcxt_get_backing_file(struct loopdev_cxt *lc);
+ extern int loopcxt_get_backing_devno(struct loopdev_cxt *lc, dev_t *devno);
+ extern int loopcxt_get_backing_inode(struct loopdev_cxt *lc, ino_t *ino);
+ extern int loopcxt_get_offset(struct loopdev_cxt *lc, uint64_t *offset);
++extern int loopcxt_get_blocksize(struct loopdev_cxt *lc, uint64_t *blocksize);
+ extern int loopcxt_get_sizelimit(struct loopdev_cxt *lc, uint64_t *size);
+ extern int loopcxt_get_encrypt_type(struct loopdev_cxt *lc, uint32_t *type);
+ extern const char *loopcxt_get_crypt_name(struct loopdev_cxt *lc);
+diff --git a/lib/loopdev.c b/lib/loopdev.c
+index daf0a81e8..d6dcec3df 100644
+--- a/lib/loopdev.c
++++ b/lib/loopdev.c
+@@ -735,6 +735,38 @@ int loopcxt_get_offset(struct loopdev_cxt *lc, uint64_t *offset)
+ 	return rc;
+ }
+ 
++/*
++ * @lc: context
++ * @blocksize: returns logical blocksize for the given device
++ *
++ * Returns: <0 on error, 0 on success
++ */
++int loopcxt_get_blocksize(struct loopdev_cxt *lc, uint64_t *blocksize)
++{
++	struct sysfs_cxt *sysfs = loopcxt_get_sysfs(lc);
++	int rc = -EINVAL;
++
++	if (sysfs)
++		rc = sysfs_read_u64(sysfs, "queue/logical_block_size", blocksize);
++
++	/* Fallback based on BLKSSZGET ioctl */
++	if (rc) {
++		int fd = loopcxt_get_fd(lc);
++		int sz = 0;
++
++		if (fd < 0)
++			return -EINVAL;
++		rc = blkdev_get_sector_size(fd, &sz);
++		if (rc)
++			return rc;
++
++		*blocksize = sz;
++	}
++
++	DBG(lc, loopdev_debug(lc, "get_blocksize [rc=%d]", rc));
++	return rc;
++}
++
+ /*
+  * @lc: context
+  * @sizelimit: returns size limit for the given device
+@@ -1288,6 +1320,24 @@ int loopcxt_set_capacity(struct loopdev_cxt *lc)
+ 	return 0;
+ }
+ 
++int loopcxt_set_blocksize(struct loopdev_cxt *lc, unsigned long blocksize)
++{
++	int fd = loopcxt_get_fd(lc);
++
++	if (fd < 0)
++		return -EINVAL;
++
++	/* Kernels prior to v4.14 don't support this ioctl */
++	if (ioctl(fd, LOOP_SET_BLOCK_SIZE, blocksize) < 0) {
++		int rc = -errno;
++		DBG(lc, loopdev_debug(lc, "LOOP_SET_BLOCK_SIZE failed: %m"));
++		return rc;
++	}
++
++	DBG(lc, loopdev_debug(lc, "logical block size set"));
++	return 0;
++}
++
+ int loopcxt_delete_device(struct loopdev_cxt *lc)
+ {
+ 	int fd = loopcxt_get_fd(lc);
+diff --git a/sys-utils/losetup.8 b/sys-utils/losetup.8
+index 9a8c1d597..ee704ca81 100644
+--- a/sys-utils/losetup.8
++++ b/sys-utils/losetup.8
+@@ -102,6 +102,8 @@ device
+ specify which columns are to be printed for the \fB\-\-list\fP output
+ .IP "\fB\-\-sizelimit \fIsize\fP"
+ the data end is set to no more than \fIsize\fP bytes after the data start
++.IP "\fB-b, \-\-logical-blocksize \fIsize\fP"
++Set the logical block size of the loop device in bytes (since Linux 4.14).
+ .IP "\fB\-P, \-\-partscan\fP"
+ force kernel to scan partition table on newly created loop device
+ .IP "\fB\-r, \-\-read-only\fP"
+diff --git a/sys-utils/losetup.c b/sys-utils/losetup.c
+index d9b0c9b61..6ba256c90 100644
+--- a/sys-utils/losetup.c
++++ b/sys-utils/losetup.c
+@@ -33,6 +33,7 @@ enum {
+ 	A_SHOW_ONE,		/* print info about one device */
+ 	A_FIND_FREE,		/* find first unused */
+ 	A_SET_CAPACITY,		/* set device capacity */
++	A_SET_BLOCKSIZE,	/* set logical block size of the loop device */
+ };
+ 
+ enum {
+@@ -46,6 +47,7 @@ enum {
+ 	COL_PARTSCAN,
+ 	COL_RO,
+ 	COL_SIZELIMIT,
++	COL_BLOCKSIZE,
+ };
+ 
+ struct tt *tt;
+@@ -68,6 +70,7 @@ static struct colinfo infos[] = {
+ 	[COL_RO]          = { "RO",           1, TT_FL_RIGHT, N_("read-only device")},
+ 	[COL_SIZELIMIT]   = { "SIZELIMIT",    5, TT_FL_RIGHT, N_("size limit of the file in bytes")},
+ 	[COL_MAJMIN]      = { "MAJ:MIN",      3, 0, N_("loop device major:minor number")},
++	[COL_BLOCKSIZE]   = { "BLOCKSIZE",    4, TT_FL_RIGHT, N_("logical block size in bytes")},
+ };
+ 
+ #define NCOLS ARRAY_SIZE(infos)
+@@ -283,6 +286,10 @@ static int set_tt_data(struct loopdev_cxt *lc, struct tt_line *ln)
+ 			tt_line_set_data(ln, i,
+ 				xstrdup(loopcxt_is_partscan(lc) ? "1" : "0"));
+ 			break;
++		case COL_BLOCKSIZE:
++			if (loopcxt_get_blocksize(lc, &x) == 0)
++				xasprintf(&np, "%jd", x);
++			break;
+ 		default:
+ 			return -EINVAL;
+ 		}
+@@ -357,6 +364,7 @@ static void usage(FILE *out)
+ 	fputs(_(" -o, --offset <num>            start at offset <num> into file\n"), out);
+ 	fputs(_(" -O, --output <cols>           specify columns to output for --list\n"), out);
+ 	fputs(_("     --sizelimit <num>         device limited to <num> bytes of the file\n"), out);
++	fputs(_(" -b  --logical-blocksize <num> set the logical block size to <num>\n"), out);
+ 	fputs(_(" -P, --partscan                create partitioned loop device\n"), out);
+ 	fputs(_(" -r, --read-only               setup read-only loop device\n"), out);
+ 	fputs(_("     --show                    print device name after setup (with -f)\n"), out);
+@@ -400,10 +408,11 @@ int main(int argc, char **argv)
+ 	struct loopdev_cxt lc;
+ 	int act = 0, flags = 0, c;
+ 	char *file = NULL;
+-	uint64_t offset = 0, sizelimit = 0;
++	uint64_t offset = 0, sizelimit = 0, blocksize = 0;
+ 	int res = 0, showdev = 0, lo_flags = 0;
+ 	char *outarg = NULL;
+ 	int list = 0;
++	unsigned long set_blocksize = 0;
+ 
+ 	enum {
+ 		OPT_SIZELIMIT = CHAR_MAX + 1,
+@@ -419,6 +428,7 @@ int main(int argc, char **argv)
+ 		{ "help", 0, 0, 'h' },
+ 		{ "associated", 1, 0, 'j' },
+ 		{ "list", 0, 0, 'l' },
++		{ "logical-blocksize", 1, 0, 'b' },
+ 		{ "offset", 1, 0, 'o' },
+ 		{ "output", 1, 0, 'O' },
+ 		{ "sizelimit", 1, 0, OPT_SIZELIMIT },
+@@ -447,7 +457,7 @@ int main(int argc, char **argv)
+ 	if (loopcxt_init(&lc, 0))
+ 		err(EXIT_FAILURE, _("failed to initialize loopcxt"));
+ 
+-	while ((c = getopt_long(argc, argv, "ac:d:De:E:fhj:lo:O:p:PrvV",
++	while ((c = getopt_long(argc, argv, "ab:c:d:De:E:fhj:lo:O:p:PrvV",
+ 				longopts, NULL)) != -1) {
+ 
+ 		err_exclusive_options(c, longopts, excl, excl_st);
+@@ -456,6 +466,10 @@ int main(int argc, char **argv)
+ 		case 'a':
+ 			act = A_SHOW;
+ 			break;
++		case 'b':
++			set_blocksize = 1;
++			blocksize = strtosize_or_err(optarg, _("failed to parse logical block size"));
++			break;
+ 		case 'c':
+ 			act = A_SET_CAPACITY;
+ 			if (loopcxt_set_device(&lc, optarg))
+@@ -537,6 +551,7 @@ int main(int argc, char **argv)
+ 		columns[ncolumns++] = COL_AUTOCLR;
+ 		columns[ncolumns++] = COL_RO;
+ 		columns[ncolumns++] = COL_BACK_FILE;
++		columns[ncolumns++] = COL_BLOCKSIZE;
+ 	}
+ 
+ 	if (act == A_FIND_FREE && optind < argc) {
+@@ -556,9 +571,15 @@ int main(int argc, char **argv)
+ 	if (!act && optind + 1 == argc) {
+ 		/*
+ 		 * losetup [--list] <device>
++		 * OR
++		 * losetup --logical-blocksize=size <device>
+ 		 */
+-		act = A_SHOW_ONE;
+-		if (loopcxt_set_device(&lc, argv[optind]))
++		if (!set_blocksize)
++			act = A_SHOW_ONE;
++		else
++			act = A_SET_BLOCKSIZE;
++		if (!is_loopdev(argv[optind]) ||
++		    loopcxt_set_device(&lc, argv[optind]))
+ 			err(EXIT_FAILURE, _("%s: failed to use device"),
+ 					argv[optind]);
+ 		optind++;
+@@ -640,6 +661,8 @@ int main(int argc, char **argv)
+ 			if (showdev)
+ 				printf("%s\n", loopcxt_get_device(&lc));
+ 			warn_size(file, sizelimit);
++			if set_blocksize
++				goto lo_set_post;
+ 		}
+ 		break;
+ 	}
+@@ -682,6 +705,14 @@ int main(int argc, char **argv)
+ 			warn(_("%s: set capacity failed"),
+ 			        loopcxt_get_device(&lc));
+ 		break;
++	case A_SET_BLOCKSIZE:
++ lo_set_post:
++		if (set_blocksize) {
++			res = loopcxt_set_blocksize(&lc, blocksize);
++			if (res)
++				warn(_("%s: set logical block size failed"),
++				        loopcxt_get_device(&lc));
++		break;
+ 	default:
+ 		usage(stderr);
+ 		break;
+-- 
+2.39.2
+

--- a/SOURCES/0002-losetup-rename-to-sector-size-and-LOG-SEC.patch
+++ b/SOURCES/0002-losetup-rename-to-sector-size-and-LOG-SEC.patch
@@ -1,0 +1,122 @@
+From b5ecef8658f0f1db92cf24abf039632382337dee Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Mon, 2 Oct 2017 11:59:57 +0200
+Subject: [PATCH 2/4] losetup: rename to --sector-size and LOG-SEC
+
+Signed-off-by: Karel Zak <kzak@redhat.com>
+
+(cherry picked from commit 76493ceba6600d3a98ad00deaf12edcf305f5ad4)
+---
+ sys-utils/losetup.8 | 16 +++++++---------
+ sys-utils/losetup.c | 12 ++++++------
+ 2 files changed, 13 insertions(+), 15 deletions(-)
+
+diff --git a/sys-utils/losetup.8 b/sys-utils/losetup.8
+index ee704ca81..48e37c198 100644
+--- a/sys-utils/losetup.8
++++ b/sys-utils/losetup.8
+@@ -7,7 +7,7 @@ Get info:
+ .sp
+ .in +5
+ .B losetup
+-.I loopdev
++[\fIloopdev\fP]
+ .sp
+ .B losetup -l
+ .RB [ \-a ]
+@@ -31,12 +31,6 @@ Delete all used loop devices:
+ .B "losetup \-D"
+ .sp
+ .in -5
+-Print name of first unused loop device:
+-.sp
+-.in +5
+-.B "losetup \-f"
+-.sp
+-.in -5
+ Set up a loop device:
+ .sp
+ .in +5
+@@ -45,6 +39,8 @@ Set up a loop device:
+ .IR offset ]
+ .RB [ \-\-sizelimit
+ .IR size ]
++.RB [ \-\-sector\-size
++.IR size ]
+ .in +8
+ .RB [ \-Pr ]
+ .RB [ \-\-show ]  " \-f" | \fIloopdev\fP
+@@ -102,8 +98,10 @@ device
+ specify which columns are to be printed for the \fB\-\-list\fP output
+ .IP "\fB\-\-sizelimit \fIsize\fP"
+ the data end is set to no more than \fIsize\fP bytes after the data start
+-.IP "\fB-b, \-\-logical-blocksize \fIsize\fP"
+-Set the logical block size of the loop device in bytes (since Linux 4.14).
++.IP "\fB-b, \-\-sector-size \fIsize\fP"
++Set the logical sector size of the loop device in bytes (since Linux 4.14). The
++option may be used when create a new loop device as well as stand-alone command
++to modify sector size of the already existing loop device.
+ .IP "\fB\-P, \-\-partscan\fP"
+ force kernel to scan partition table on newly created loop device
+ .IP "\fB\-r, \-\-read-only\fP"
+diff --git a/sys-utils/losetup.c b/sys-utils/losetup.c
+index 6ba256c90..ffd4c682f 100644
+--- a/sys-utils/losetup.c
++++ b/sys-utils/losetup.c
+@@ -47,7 +47,7 @@ enum {
+ 	COL_PARTSCAN,
+ 	COL_RO,
+ 	COL_SIZELIMIT,
+-	COL_BLOCKSIZE,
++	COL_LOGSEC,
+ };
+ 
+ struct tt *tt;
+@@ -70,7 +70,7 @@ static struct colinfo infos[] = {
+ 	[COL_RO]          = { "RO",           1, TT_FL_RIGHT, N_("read-only device")},
+ 	[COL_SIZELIMIT]   = { "SIZELIMIT",    5, TT_FL_RIGHT, N_("size limit of the file in bytes")},
+ 	[COL_MAJMIN]      = { "MAJ:MIN",      3, 0, N_("loop device major:minor number")},
+-	[COL_BLOCKSIZE]   = { "BLOCKSIZE",    4, TT_FL_RIGHT, N_("logical block size in bytes")},
++	[COL_LOGSEC]      = { "LOG-SEC",      4, TT_FL_RIGHT, N_("logical sector size in bytes")},
+ };
+ 
+ #define NCOLS ARRAY_SIZE(infos)
+@@ -286,7 +286,7 @@ static int set_tt_data(struct loopdev_cxt *lc, struct tt_line *ln)
+ 			tt_line_set_data(ln, i,
+ 				xstrdup(loopcxt_is_partscan(lc) ? "1" : "0"));
+ 			break;
+-		case COL_BLOCKSIZE:
++		case COL_LOGSEC:
+ 			if (loopcxt_get_blocksize(lc, &x) == 0)
+ 				xasprintf(&np, "%jd", x);
+ 			break;
+@@ -364,7 +364,7 @@ static void usage(FILE *out)
+ 	fputs(_(" -o, --offset <num>            start at offset <num> into file\n"), out);
+ 	fputs(_(" -O, --output <cols>           specify columns to output for --list\n"), out);
+ 	fputs(_("     --sizelimit <num>         device limited to <num> bytes of the file\n"), out);
+-	fputs(_(" -b  --logical-blocksize <num> set the logical block size to <num>\n"), out);
++	fputs(_(" -b  --sector-size <num>       set the logical sector size to <num>\n"), out);
+ 	fputs(_(" -P, --partscan                create partitioned loop device\n"), out);
+ 	fputs(_(" -r, --read-only               setup read-only loop device\n"), out);
+ 	fputs(_("     --show                    print device name after setup (with -f)\n"), out);
+@@ -428,7 +428,7 @@ int main(int argc, char **argv)
+ 		{ "help", 0, 0, 'h' },
+ 		{ "associated", 1, 0, 'j' },
+ 		{ "list", 0, 0, 'l' },
+-		{ "logical-blocksize", 1, 0, 'b' },
++		{ "sector-size", 1, 0, 'b' },
+ 		{ "offset", 1, 0, 'o' },
+ 		{ "output", 1, 0, 'O' },
+ 		{ "sizelimit", 1, 0, OPT_SIZELIMIT },
+@@ -551,7 +551,7 @@ int main(int argc, char **argv)
+ 		columns[ncolumns++] = COL_AUTOCLR;
+ 		columns[ncolumns++] = COL_RO;
+ 		columns[ncolumns++] = COL_BACK_FILE;
+-		columns[ncolumns++] = COL_BLOCKSIZE;
++		columns[ncolumns++] = COL_LOGSEC;
+ 	}
+ 
+ 	if (act == A_FIND_FREE && optind < argc) {
+-- 
+2.39.2
+

--- a/SOURCES/0003-losetup-properly-use-sector-size-when-create-a-new-d.patch
+++ b/SOURCES/0003-losetup-properly-use-sector-size-when-create-a-new-d.patch
@@ -1,0 +1,80 @@
+From e79193698c704dce4f17f7a872da59d7c9c6eba2 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Tue, 22 Jan 2019 11:50:20 +0100
+Subject: [PATCH 3/4] losetup: properly use --sector-size when create a new
+ device
+
+The --partscan functionality depends on sector size. Make sure
+sector size is set before we force kernel to scan the device for
+partitions. For example:
+
+ losetup -f loopfile --sector-size 4KiB --partscan --show
+
+where 'loopfile' contains GPT with 4096 sectors.
+
+Reported-by: Jeffrey Ferreira <jeffpferreira@gmail.com>
+Signed-off-by: Karel Zak <kzak@redhat.com>
+(cherry picked from commit 422f0e9f206a145c59a71333dad20d38cbbfc0c4)
+---
+ sys-utils/losetup.8 |  4 +++-
+ sys-utils/losetup.c | 15 +++++++--------
+ 2 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/sys-utils/losetup.8 b/sys-utils/losetup.8
+index 48e37c198..6a4cb450e 100644
+--- a/sys-utils/losetup.8
++++ b/sys-utils/losetup.8
+@@ -103,7 +103,9 @@ Set the logical sector size of the loop device in bytes (since Linux 4.14). The
+ option may be used when create a new loop device as well as stand-alone command
+ to modify sector size of the already existing loop device.
+ .IP "\fB\-P, \-\-partscan\fP"
+-force kernel to scan partition table on newly created loop device
++force kernel to scan partition table on newly created loop device.  Note that the
++partition table parsing depends on sector sizes.  The default is sector size is 512 bytes,
++otherwise you need to use use the option \fB\-\-sector\-size\fR together with \fB\-\-partscan\fR.
+ .IP "\fB\-r, \-\-read-only\fP"
+ setup read-only loop device
+ .IP "\fB\-\-show\fP"
+diff --git a/sys-utils/losetup.c b/sys-utils/losetup.c
+index ffd4c682f..40284e8f5 100644
+--- a/sys-utils/losetup.c
++++ b/sys-utils/losetup.c
+@@ -639,6 +639,9 @@ int main(int argc, char **argv)
+ 				loopcxt_set_sizelimit(&lc, sizelimit);
+ 			if (lo_flags)
+ 				loopcxt_set_flags(&lc, lo_flags);
++			if (blocksize > 0)
++				loopcxt_set_blocksize(&lc, blocksize);
++
+ 			if ((res = loopcxt_set_backing_file(&lc, file))) {
+ 				warn(_("%s: failed to use backing file"), file);
+ 				break;
+@@ -661,8 +664,6 @@ int main(int argc, char **argv)
+ 			if (showdev)
+ 				printf("%s\n", loopcxt_get_device(&lc));
+ 			warn_size(file, sizelimit);
+-			if set_blocksize
+-				goto lo_set_post;
+ 		}
+ 		break;
+ 	}
+@@ -706,12 +707,10 @@ int main(int argc, char **argv)
+ 			        loopcxt_get_device(&lc));
+ 		break;
+ 	case A_SET_BLOCKSIZE:
+- lo_set_post:
+-		if (set_blocksize) {
+-			res = loopcxt_set_blocksize(&lc, blocksize);
+-			if (res)
+-				warn(_("%s: set logical block size failed"),
+-				        loopcxt_get_device(&lc));
++		res = loopcxt_set_blocksize(&lc, blocksize);
++		if (res)
++			warn(_("%s: set logical block size failed"),
++			        loopcxt_get_device(&lc));
+ 		break;
+ 	default:
+ 		usage(stderr);
+-- 
+2.39.2
+

--- a/SOURCES/0004-losetup-Fix-typo-for-the-sector-size-docs.patch
+++ b/SOURCES/0004-losetup-Fix-typo-for-the-sector-size-docs.patch
@@ -1,0 +1,26 @@
+From 80760625f29f1b67a6bf8e8dfe9bfb37fd9a743b Mon Sep 17 00:00:00 2001
+From: Alberto Ruiz <aruiz@gnome.org>
+Date: Thu, 12 May 2022 23:35:21 +0200
+Subject: [PATCH 4/4] losetup: Fix typo for the --sector-size docs
+
+(cherry picked from commit 034727a2e48b67673fea59a746b5b5c077bc2b03)
+---
+ sys-utils/losetup.8 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys-utils/losetup.8 b/sys-utils/losetup.8
+index 6a4cb450e..a8cc4d19e 100644
+--- a/sys-utils/losetup.8
++++ b/sys-utils/losetup.8
+@@ -100,7 +100,7 @@ specify which columns are to be printed for the \fB\-\-list\fP output
+ the data end is set to no more than \fIsize\fP bytes after the data start
+ .IP "\fB-b, \-\-sector-size \fIsize\fP"
+ Set the logical sector size of the loop device in bytes (since Linux 4.14). The
+-option may be used when create a new loop device as well as stand-alone command
++option may be used when creating a new loop device as well as a stand-alone command
+ to modify sector size of the already existing loop device.
+ .IP "\fB\-P, \-\-partscan\fP"
+ force kernel to scan partition table on newly created loop device.  Note that the
+-- 
+2.39.2
+

--- a/SPECS/util-linux.spec
+++ b/SPECS/util-linux.spec
@@ -2,7 +2,7 @@
 Summary: A collection of basic system utilities
 Name: util-linux
 Version: 2.23.2
-Release: 52%{?dist}.1
+Release: 52.1%{?dist}
 License: GPLv2 and GPLv2+ and LGPLv2+ and BSD with advertising and Public Domain
 Group: System Environment/Base
 URL: http://en.wikipedia.org/wiki/Util-linux
@@ -394,6 +394,11 @@ Patch150: 0150-libblkid-minix-Match-minix-superblock-types.patch
 Patch151: 0151-libblkid-minix-Sanity-check-superblock-s_state-for-v.patch
 Patch152: 0152-libblkid-minix-Use-same-checks-for-version-3.patch
 
+# XCP-ng patches
+Patch1000: 0001-losetup-Add-support-for-logical-block-size.patch
+Patch1001: 0002-losetup-rename-to-sector-size-and-LOG-SEC.patch
+Patch1002: 0003-losetup-properly-use-sector-size-when-create-a-new-d.patch
+Patch1003: 0004-losetup-Fix-typo-for-the-sector-size-docs.patch
 
 %description
 The util-linux package contains a large variety of low-level system
@@ -1127,6 +1132,9 @@ fi
 %{_libdir}/pkgconfig/uuid.pc
 
 %changelog
+* Mon Feb 12 2024 Yann Dirson <yann.dirson@vates.fr> 2.23.2-52.1
+- backport --sector-size support
+
 * Thu Jul 12 2018 Karel Zak <kzak@redhat.com> 2.23.2-52.el7_5.1
 - fix #1594681 - blkid does not output swap area
 


### PR DESCRIPTION
This will allow to add a translation layer to use 512B blocks emulation atop 4KB blocks disks, until upper software layers can use 4KB blocks directly.